### PR TITLE
applied updates to fix thumbnail display inconsistencies in grid item…

### DIFF
--- a/src/components/IIIF_Item.svelte
+++ b/src/components/IIIF_Item.svelte
@@ -34,7 +34,7 @@
         _manifest = JSON.parse(manifestJSON);
 
         item.media = getManifestResourceUrl(_manifest) || item.media;
-        item.thumbnail = thumbnailUrl || getManifestThumbnailUrl(_manifest) || item.thumbnail;
+        item.thumbnail = thumbnailUrl || item.thumbnail;
 
       } catch (error) {
         Logger.module().error("Error parsing IIIF manifest data: " + error);

--- a/src/components/Kaltura_Content.svelte
+++ b/src/components/Kaltura_Content.svelte
@@ -37,8 +37,11 @@
     let previewImageElement;
     let htmlPlayerElement;
     let htmlPlayer;
+    let showLoadMessage;;
 
     const init = () => {
+        showLoadMessage = true;
+
         if(kalturaUrl) {
             kalturaUrl = validateKalturaUrl(kalturaUrl) ? kalturaUrl : null;
             if(!kalturaUrl) {
@@ -57,6 +60,8 @@
     }
 
     const onLoadIframe = () => {
+        console.log("test: on load kal iframe")
+
         iframeSection.style.visibility = "visible";
 
         window.addEventListener('resize', function(event) {
@@ -64,6 +69,8 @@
         }, true);
 
         dispatch('loaded', {entryId});
+
+        showLoadMessage = false;
     }
 
     const onClickKalturaPreview = (event) => {
@@ -144,11 +151,26 @@
                 <iframe bind:this={iframeElement} on:load={onLoadIframe} id={kalturaUniqueObjectID} {title} src={kalturaUrl} allowfullscreen webkitallowfullscreen mozAllowFullScreen allow='autoplay *; fullscreen *; encrypted-media *' frameborder='0'></iframe>
                 <div class="subframe-content"></div>
             </div>
+            
+            {#if showLoadMessage}
+                <div class="kaltura-player-load-message">
+                    Loading media player...
+                </div>
+            {/if}
         {/if}
     {/if}
 </div>
 
 <style>
+    .kaltura-player-load-message {
+        position: absolute;
+        top: calc(50% - 50px);
+        z-index: 10;
+        text-align: center;
+        color: black;
+        width: 100%;
+    }
+
     .kaltura-content:not(.embedded) {
         height: 100%;
         width: 100%;

--- a/src/components/Media_Item.svelte
+++ b/src/components/Media_Item.svelte
@@ -30,7 +30,7 @@
     const RESOURCE = new ResourceUrl(item.is_member_of_exhibit);
 
     const DEFAULT_ITEM_TITLE = Settings.exhibitItemDefaultTitle;
-    const LOAD_MESSAGE = "Loading media...";
+    const LOAD_MESSAGE = "";
 
     // component options
     const URL_PATTERN = /^https?:\/\//;

--- a/src/components/Media_Item_Preview.svelte
+++ b/src/components/Media_Item_Preview.svelte
@@ -6,8 +6,11 @@
      * 
      * @param {Object} item - The exhibit item object containing metadata and resource information.
      * @param {Object} args - Additional arguments for configuring the component behavior [
-     *  args.isInteractive (boolean, default: true) to enable/disable click interaction, 
+     *  args.isThumbnail (boolean, default: false) will use the item thumbnail if specified, or attempt to create a thumbnail using available iiif service
+     *  args.verifyThumbnail (boolean, default: false) if the item has a thumbnail, it will be used. if not, the media will be shown in the preview]
+     *  args.isInteractive (boolean, default: true) if true, preview is clickable and shows the text overlay; if false, preview is not clickable and is skipped in tab order 
      *  args.link (string, optional) to specify a URL to navigate to on click instead of dispatching event, 
+     *  args.title (string, optional) set the title attribute on the preview button (only if interactive)
      * ]
      * @param {number} width - Desired width for the preview image (optional).
      * @param {number} height - Desired height for the preview image (optional).
@@ -38,11 +41,13 @@
 
     const dispatch = createEventDispatcher();
 
-    const { 
-        isThumbnail,
+    let { 
+        isThumbnail = false,
+        verifyThumbnail = false,
         isInteractive = true,
         link = null,
         title = null,
+
     } = args;
 
     // global settings
@@ -76,12 +81,16 @@
 
     // module variables
     let _previewUrl;
-    let _isPlaceholderImage;
+    let _isPlaceholderImage; // TODO: to _hasError
     let _previewImageElement;
     let _showOverlay = true;
 
     const init = async () => {
         _isPlaceholderImage = false;
+
+        if(verifyThumbnail) {
+            isThumbnail = (thumbnailIIIF == null && thumbnail == null) ? false : true;
+        }
 
         _previewUrl = await getPreviewUrl(isThumbnail);
         if(!_previewUrl) {
@@ -139,21 +148,30 @@
                  *
                  * 1. iiif api thumbnail url from item data
                  * 2. thumbnail (from iiif manifest or remote image uri)
-                 * 3. get cropped image via iiif image api
-                 * 4. null (no thumbnail available)
+                 * 3. get cropped image via iiif service url
+                 * 4. use fullsize iiif image
+                 * 5. null (no thumbnail available)
                  */
-                iiifThumbnailImageUrl || thumbnail || (iiifServiceUrl ? `${iiifServiceUrl}/full/${IMAGE_THUMBNAIL_WIDTH},/0/default.jpg` : false) || null :
+                iiifThumbnailImageUrl || 
+                thumbnail || 
+                (iiifServiceUrl ? `${iiifServiceUrl}/full/${IMAGE_THUMBNAIL_WIDTH},/0/default.jpg` : false) || 
+                iiifImageUrl ||
+                null :
 
                 /*
                  * source options for fullsize preview image:
                  *
-                 * 1. iiif api thumbnail url from item data
-                 * 2. iiif api image url from item data
-                 * 3. thumbnail (from iiif manifest or remote image uri)
-                 * 4. media (from iiif manifest or remote image uri)
+                 * 1. iiif api image url from item data
+                 * 2. media (from iiif manifest or remote image uri)
+                 * 3. iiif api thumbnail url from item data
+                 * 4. thumbnail (from iiif manifest or remote image uri)
                  * 5. null (no preview available)
                  */
-                iiifThumbnailImageUrl || iiifImageUrl || thumbnail || media || null;
+                iiifImageUrl || 
+                media || 
+                iiifThumbnailImageUrl || 
+                thumbnail || 
+                null;
         }
 
         // handle local filesystem source urls for image items (media/thumbnail are expected to be file names)
@@ -221,20 +239,30 @@
                  *
                  * 1. iiif api thumbnail url from item data
                  * 2. thumbnail (from iiif manifest or remote image uri)
-                 * 3. get cropped image via iiif image api
-                 * 4. null (no thumbnail available)
+                 * 3. get cropped image via iiif service url
+                 * 4. iiif image url (fullsize)
+                 * 5. null (no thumbnail available)
                  */
-                iiifThumbnailImageUrl || thumbnail || (iiifServiceUrl ? `${iiifServiceUrl}/full/${IMAGE_THUMBNAIL_WIDTH},/0/default.jpg` : false) || null :
+                iiifThumbnailImageUrl || 
+                thumbnail || 
+                (iiifServiceUrl ? `${iiifServiceUrl}/full/${IMAGE_THUMBNAIL_WIDTH},/0/default.jpg` : false) || 
+                iiifImageUrl ||
+                null :
 
                 /*
                  * source options for fullsize preview image:
                  *
-                 * 1. iiif api thumbnail url from item data
-                 * 2. iiif api image url from item data
-                 * 3. thumbnail (from iiif manifest or remote image uri)
-                 * 4. null (no preview available)
+                 * 1. iiif api image url from item data
+                 * 2. get full image via iiif service url
+                 * 3. iiif api thumbnail url from item data
+                 * 4. thumbnail (from iiif manifest or remote image uri)
+                 * 5. null (no preview available)
                  */
-                iiifThumbnailImageUrl || iiifImageUrl || thumbnail || null;
+                iiifImageUrl || 
+                (iiifServiceUrl ? `${iiifServiceUrl}/full/max/0/default.jpg` : false) || 
+                iiifThumbnailImageUrl || 
+                thumbnail || 
+                null;
         }
 
         // handle local filesystem source urls for pdf items (media/thumbnail are expected to be file names)

--- a/src/components/OpenSeadragon_Content.svelte
+++ b/src/components/OpenSeadragon_Content.svelte
@@ -70,7 +70,7 @@
     <div class="openseadragon content" id="openseadragon1">
 
         <div class="openseadragon-load-message" bind:this={loadMessage}>
-            Loading Openseadragon Viewer...
+            Loading image...
         </div>
 
     </div>
@@ -84,6 +84,8 @@
 .openseadragon-load-message {
     position: relative;
     top: calc(50% - 50px);
+    z-index: 10;
+    text-align: center;
 }
 
 .openseadragon-container {

--- a/src/components/Repository_Related_Items.svelte
+++ b/src/components/Repository_Related_Items.svelte
@@ -205,7 +205,14 @@
                   <h3>Seen in the exhibit</h3>
 
                   <div class="exhibit-item-preview">
-                     <MediaItemPreview item={_relatedItemsDisplay[index]} args={{isInteractive: false, title: caption}} on:click-item />
+                     <MediaItemPreview 
+                        item={_relatedItemsDisplay[index]} 
+                        args={{
+                           isThumbnail: true,
+                           isInteractive: false, 
+                           title: caption
+                        }} 
+                        on:click-item />
                   </div>
 
                   <h4>Explore similar subjects</h4>

--- a/src/templates/partials/Grid_Item_Image_Text.svelte
+++ b/src/templates/partials/Grid_Item_Image_Text.svelte
@@ -8,7 +8,8 @@
     'use strict'
 
     import { onMount } from 'svelte';
-    import Item from './Item.svelte';
+    //import Item from './Item.svelte';
+    import Item_Preview from '../../components/Media_Item_Preview.svelte';
     import Item_Display from '../../components/Item_Display.svelte';
 
     import { MEDIA_POSITION, ITEM_TYPE } from '../../config/global-constants';
@@ -61,7 +62,18 @@
     {/if}
 
     {#if title}<h4>{@html title}</h4>{/if}
-    <Item_Display {item} template={Item} args={{showTitle: true, gridItem: true}} on:click-item />
+    <Item_Display 
+        {item} 
+        
+        template={Item_Preview} 
+        args={{
+            // isThumbnail: true,
+            verifyThumbnail: true,
+            showTitle: true, 
+            gridItem: true,
+        }} 
+        on:click-item 
+    />
 </div>
 
 <style>

--- a/src/templates/partials/Grid_Item_Vertical_Timeline.svelte
+++ b/src/templates/partials/Grid_Item_Vertical_Timeline.svelte
@@ -46,7 +46,15 @@
                 {#if media} 
                     <div class="vertical-timeline-item">
                         <div class="preview">
-                            <Item_Display {item} template={Item_Preview} args={{showTitle: true}} on:click-item />
+                            <Item_Display 
+                                {item} 
+                                
+                                template={Item_Preview} 
+                                args={{
+                                    isThumbnail: true,
+                                    showTitle: true,
+                                }} 
+                                on:click-item />
                         </div>
                     </div>
                 {/if}

--- a/src/templates/partials/Search_Result.svelte
+++ b/src/templates/partials/Search_Result.svelte
@@ -61,7 +61,15 @@
             <Exhibit_Preview exhibit={result} link={result.link} width="200" height="200" on:image-loaded={onPreviewImageLoad} />  
 
         {:else}
-            <Item_Preview item={result} width="200" args={{link: (result.link || false), isInteractive: false}} on:image-loaded={onPreviewImageLoad} />
+            <Item_Preview 
+                item={result} 
+                width="200" 
+                args={{
+                    isThumbnail: true,
+                    link: (result.link || false), 
+                    isInteractive: false,
+                }} 
+                on:image-loaded={onPreviewImageLoad} />
         {/if}
     </div>
 


### PR DESCRIPTION
…, search result and RRI previews

updates:

iiif_item: 
- removed the thumbnail field assignment from manifest if the thumbnail has not been added by the user (in this case, there should be no thumbnail present in the item data, regardless of if there is one in the manifest)

media_item_preview: 
- updated the preview source heirchy logic to fix erroneous assignment of thumbnail source when the thumbnail flag is false
- added "verifyThumbnail" flag to args, to automatically set the "isThumbnail" flag to true if the thumbnail is present in the item data (and false if it is not) This enables the grid to show a fullsize image for items with no thumbnail aded by user

search_result, and VTL grid items:
- specify isThumbnail = true in preview 

standard grid items:
- specify verifyThumbnail = true in preview